### PR TITLE
PR: Spacer 컴포넌트 생성, Layout 컴포넌트 에 적용

### DIFF
--- a/src/components/@index.js
+++ b/src/components/@index.js
@@ -4,6 +4,7 @@ import { InfiniteList, PostCard, Preview } from './infinite_list/@index';
 import { Layout } from './layout/@index';
 import Poster from './poster';
 import Skeleton from './skeleton';
+import Spacer from './spacer';
 import TopButton from './top_button';
 
 export {
@@ -15,5 +16,6 @@ export {
 	Poster,
 	Preview,
 	Skeleton,
+	Spacer,
 	TopButton,
 };

--- a/src/components/layout/@index.js
+++ b/src/components/layout/@index.js
@@ -1,2 +1,5 @@
+import Header from './header';
 import Layout from './layout';
-export { Layout };
+import SearchArea from './search_area';
+import SideBar from './sidebar';
+export { Header, Layout, SearchArea, SideBar };

--- a/src/components/layout/header.jsx
+++ b/src/components/layout/header.jsx
@@ -1,10 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { color, flexAlign } from '../../styles/themes/@index';
-import SearchArea from './search_area';
+import { SearchArea } from './@index';
 
 /**
-
+ * @param {string} $bgColor 헤더 배경 색상
+ * @param {string} $color 헤더 내부 요소 색생
+ * @param {$borderColor} $borderColor 헤더 경계선 색상
  * @description
  * 상단에 사이트 이름, 입력창을 담을 header 입니다.
  */

--- a/src/components/layout/layout.jsx
+++ b/src/components/layout/layout.jsx
@@ -1,7 +1,8 @@
 import { Outlet } from 'react-router-dom';
-import { color } from '../../styles/themes/@index';
-import Header from './header';
-import SideBar from './sidebar';
+import styled from 'styled-components';
+import { color, flexAlign } from '../../styles/themes/@index';
+import { Spacer } from '../@index';
+import { Header, SideBar } from './@index';
 
 /**
  * @component
@@ -15,13 +16,29 @@ const Layout = (
 	$color = color.gray[900],
 	$borderColor = color.black[900]
 ) => {
+	/** 좌측 사이바 영역의 너비 */
+	const sideBarWidth = '12rem';
+
 	return (
 		<>
 			<Header {...$bgColor} {...$color} {...$borderColor} />
-			<SideBar {...$bgColor} {...$color} {...$borderColor} />
-			<Outlet />
+			<SideBar
+				{...$bgColor}
+				{...$color}
+				{...$borderColor}
+				$width={sideBarWidth}
+			/>
+
+			<Div_PageContentsContainer>
+				<Spacer $width={sideBarWidth} />
+				<Outlet />
+			</Div_PageContentsContainer>
 		</>
 	);
 };
-
 export default Layout;
+
+// Header, SideBar 컴포넌트 외 어떤 페이지를 구성하는 컴포넌트를 감쌉니다.
+const Div_PageContentsContainer = styled.div`
+	${flexAlign.flexStart}
+`;

--- a/src/components/layout/search_area.jsx
+++ b/src/components/layout/search_area.jsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { color, flexAlign, fontWeight } from '../../styles/themes/@index';
-import Button from '../button';
-/**
+import { Button } from '../@index';
 
+/**
  * @description
  * 상단에 영화제목을 검색하면 해당영화를 찾아주는 검색창 컴포넌트입니다.
  */

--- a/src/components/layout/sidebar.jsx
+++ b/src/components/layout/sidebar.jsx
@@ -9,6 +9,12 @@ import {
 } from '../../styles/themes/@index';
 
 /**
+ * @component
+ * @param {string} $bgColor 사이드바 배경색상
+ * @param {string} $color 사이드바 내부요소 색상
+ * @param {string} $borderColor 사이드바 경계선 색상
+ * @param {string} $width 사이드바 너비
+ *
  * @description
  * 좌측에 navigation function 이 부여된 버튼리스트를 담을 사이드바 입니다.
  */
@@ -16,11 +22,12 @@ const SideBar = ({
 	$bgColor = color.black[100],
 	$color = color.gray[900],
 	$borderColor = color.black[900],
+	$width = '12rem',
 }) => {
 	const navigate = useNavigate();
 
 	return (
-		<S.Ul_CategoryList {...{ $bgColor, $color, $borderColor }}>
+		<S.Ul_CategoryList {...{ $bgColor, $color, $borderColor, $width }}>
 			{Object.entries(sidebarCategory).map((cate, idx) => {
 				return (
 					<S.Li_Category
@@ -45,7 +52,7 @@ const Ul_CategoryList = styled.ul`
 	top: 0%;
 	z-index: 10000;
 
-	width: 12rem;
+	width: ${({ $width }) => $width};
 	height: 100vh;
 
 	color: ${({ $color }) => $color};

--- a/src/components/spacer.jsx
+++ b/src/components/spacer.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 /**
  * @component
  * @param {string} [$width='0px'] 가로길이 (기본값: '0px')
- * @param {string} [$height=`0px`] 세로길이 (기본값: '0px')
+ * @param {string} [$height=`0px`] 세로길이 (기본값:'0px')
  * @returns {JSX.Element}
  */
 const Spacer = ({ $width = '0px', $height = '0px' }) => {
@@ -16,6 +16,6 @@ const Div_Spacer = styled.div`
 	min-width: ${({ $width }) => $width};
 	height: ${({ $height }) => $height};
 	min-height: ${({ $height }) => $height};
-	background-color: red;
+	background-color: none;
 	display: inline-block;
 `;

--- a/src/components/spacer.jsx
+++ b/src/components/spacer.jsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
+/**
+ * @component
+ * @param {string} [$width='0px'] 가로길이 (기본값: '0px')
+ * @param {string} [$height=`0px`] 세로길이 (기본값: '0px')
+ * @returns {JSX.Element}
+ */
 const Spacer = ({ $width = '0px', $height = '0px' }) => {
-	console.log($width, $height);
 	return <Div_Spacer {...{ $width, $height }} />;
 };
 

--- a/src/components/spacer.jsx
+++ b/src/components/spacer.jsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+const Spacer = ({ $width = '0px', $height = '0px' }) => {
+	console.log($width, $height);
+	return <Div_Spacer {...{ $width, $height }} />;
+};
+
+export default Spacer;
+
+const Div_Spacer = styled.div`
+	width: ${({ $width }) => $width};
+	min-width: ${({ $width }) => $width};
+	height: ${({ $height }) => $height};
+	min-height: ${({ $height }) => $height};
+	background-color: red;
+	display: inline-block;
+`;

--- a/src/pages/@index.js
+++ b/src/pages/@index.js
@@ -1,4 +1,4 @@
-import BoardPage from './board_page/board_page';
+import BoardPage from './board_page';
 import DetailPage from './detail_page';
-import HomePage from './home_page/home_page';
+import HomePage from './home_page';
 export { BoardPage, DetailPage, HomePage };

--- a/src/pages/board_page.jsx
+++ b/src/pages/board_page.jsx
@@ -7,15 +7,15 @@ import {
 	PostCard,
 	Spacer,
 	TopButton,
-} from '../../components/@index';
-import pageNames from '../../constants/texts/page_names';
-import useInfiniteMovieData from '../../hooks/use_infinite_movie_data';
+} from '../components/@index';
+import pageNames from '../constants/texts/page_names';
+import useInfiniteMovieData from '../hooks/use_infinite_movie_data';
 import {
 	color,
 	flexAlign,
 	fontSize,
 	fontWeight,
-} from '../../styles/themes/@index';
+} from '../styles/themes/@index';
 
 /**
  * /**

--- a/src/pages/board_page/board_page.jsx
+++ b/src/pages/board_page/board_page.jsx
@@ -5,6 +5,7 @@ import {
 	AlignContainer,
 	InfiniteList,
 	PostCard,
+	Spacer,
 	TopButton,
 } from '../../components/@index';
 import pageNames from '../../constants/texts/page_names';
@@ -48,10 +49,9 @@ const BoardPage = () => {
 	return (
 		<>
 			<AlignContainer $compressibility="10%">
-				<br />
+				<Spacer $height="10px" />
 				<S.H1_CategoryText>{pageNames[filter]}</S.H1_CategoryText>
-				<br />
-
+				<Spacer $height="12px" />
 				<InfiniteScroll hasMore={hasNextPage} loadMore={() => fetchNextPage()}>
 					<S.Div_ListContainer>
 						<InfiniteList data={data} renderComponent={PostCard} />

--- a/src/pages/detail_page.jsx
+++ b/src/pages/detail_page.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router';
 import styled from 'styled-components';
-import { AlignContainer, Poster } from '../components/@index';
+import { AlignContainer, Poster, Spacer } from '../components/@index';
 import movies from '../constants/query_keys/movies';
 import moviesFetchFn from '../libs/axios/movie';
 import { color, flexAlign } from '../styles/themes/@index';
@@ -32,12 +32,12 @@ const DetailPage = () => {
 			>
 				<S.Div_ContentContainer>
 					<Poster
-						$width="40rem"
+						$width="35rem"
 						src={import.meta.env.VITE_APP_MOVIES_API_IMG_URL + data.poster_path}
 					/>
 					<S.Div_TextArea>
 						<H1_Title>{data.title}</H1_Title>
-						<br />
+						<Spacer $height="30px" />
 						<h2>개요</h2>
 						<S.P_Overview>
 							{data.overview ? (
@@ -46,7 +46,7 @@ const DetailPage = () => {
 								<p>아쉽지만.. 미리보기가 없습니다. 영화관에서 확인하세요^^</p>
 							)}
 						</S.P_Overview>
-						<br />
+						<Spacer $height="15px" />
 						<h3>부가정보</h3>
 						<S.Sec_AdditionalInfo>
 							<p>
@@ -75,33 +75,30 @@ const Img_BackgroundImg = styled.img`
 	opacity: 0.4;
 	z-index: 0;
 `;
-
 const Div_ContentContainer = styled.div`
 	width: 100%;
 	height: 100%;
-
 	${flexAlign.alignCenter}
 	${flexAlign.justifyBetween}
 `;
 
 const Div_TextArea = styled.div`
 	color: ${color.gray[900]};
-	width: 60rem;
-	height: 53rem;
+	width: 55rem;
+	height: 46rem;
 	${flexAlign.directionColumn}
+	${flexAlign.justifyCenter}
 	word-break: keep-all;
-	gap: 1rem;
 `;
 
 const H1_Title = styled.h1`
-	height: 25%;
+	max-height: 20%;
 `;
 const P_Overview = styled.p`
-	height: 70%;
+	max-height: 60%;
 `;
-
 const Sec_AdditionalInfo = styled.section`
-	height: 30%;
+	max-height: 15%;
 `;
 
 const S = {

--- a/src/pages/home_page.jsx
+++ b/src/pages/home_page.jsx
@@ -1,6 +1,6 @@
 import InfiniteScroll from 'react-infinite-scroller';
-import { InfiniteList, Preview, TopButton } from '../../components/@index';
-import useInfiniteMovieData from '../../hooks/use_infinite_movie_data';
+import { InfiniteList, Preview, TopButton } from '../components/@index';
+import useInfiniteMovieData from '../hooks/use_infinite_movie_data';
 
 const HomePage = () => {
 	const { data, fetchNextPage, isLoading, hasNextPage } = useInfiniteMovieData({


### PR DESCRIPTION
- [design: Spacer 컴포넌트 생성, Layout 컴포넌트 에 적용](https://github.com/2023-frontend1/FilmVista/commit/50e3f169a583a5d18ad4ce163955f821964a2ce3)
  - jsx 요소 사이에 공간을 부여할 수 있는 Spacer 컴포넌트를 작성했습니다.
  - 아래와 같이 Sidebar(position이 `absolute`) 밑으로 page 요소가 숨어버리는 문제를 해결하기위해, Layout 에 Sidebar 와 같은 크기의 Spacer를 부여했습니다.
  - **기존**
  - <img width="350" alt="기존" src="https://github.com/2023-frontend1/FilmVista/assets/50646145/2e832b42-f181-4156-b509-a4e14194bd2e">
  - **Spacer 부여 후**
  - <img width="350" alt="Spacer 부여 후" src="https://github.com/2023-frontend1/FilmVista/assets/50646145/29d66470-e041-41c1-ac9d-e0ed46230756">


